### PR TITLE
Relax censoring to only apply to the main chat. Requested by Paul.

### DIFF
--- a/src/net/darthcraft/dcmod/addons/ChatFilter.java
+++ b/src/net/darthcraft/dcmod/addons/ChatFilter.java
@@ -61,6 +61,8 @@ public class ChatFilter extends DarthCraftAddon {
 
     // Events
     public void onPlayerChat(AsyncPlayerChatEvent event) {
+        if (event.isCancelled())
+            return;
         final Player player = event.getPlayer();
         final PlayerInfo info = plugin.playerManager.getInfo(player);
 

--- a/src/net/darthcraft/dcmod/listener/PlayerListener.java
+++ b/src/net/darthcraft/dcmod/listener/PlayerListener.java
@@ -17,12 +17,13 @@ public class PlayerListener implements Listener {
         this.plugin = plugin;
     }
 
-    @EventHandler(ignoreCancelled = true, priority = EventPriority.NORMAL)
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
     public void onPlayerChat(AsyncPlayerChatEvent event) {
         plugin.trollMode.onPlayerChat(event);
-        plugin.chatFilter.onPlayerChat(event);
         plugin.adminChat.onPlayerChat(event);
         plugin.adminBusy.onPlayerChat(event);
+        // Make sure this is last to only censor the main chat
+        plugin.chatFilter.onPlayerChat(event);
     }
 
     @EventHandler(priority = EventPriority.MONITOR)


### PR DESCRIPTION
Since, according to Brett, the only thing that is supposed to be censored is the main chat. This commit allows censored words to be said in private, like admin chat. There is one side effect which is the lack of replacements happening on anything other than the main chat thread.
