### PR TITLE
Resolve issue #103 | Spigot not seeing commands

### DIFF
--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -84,3 +84,9 @@ commands:
   pie:
       description: What flavour pie did you make? PI Flavour! 
       usage: /<command>
+  tc: 
+      description: Talk in TradeChat
+      usage: /<command> <message>
+  hidemyass:
+      description: Enable vanish mode
+      usage: /<command>


### PR DESCRIPTION
Hi there,
Spigot does not see these commands due to not being added to the plugin.yml.   This pull should fix that issue.